### PR TITLE
Replace f64 math with f32

### DIFF
--- a/src/cubehelix.rs
+++ b/src/cubehelix.rs
@@ -1,18 +1,18 @@
 #![allow(clippy::many_single_char_names)]
 
 use crate::Color;
-use std::f64::consts as f64;
+use std::f32::consts as f32;
 
 #[derive(Copy, Clone)]
 pub(crate) struct Cubehelix {
-    pub h: f64,
-    pub s: f64,
-    pub l: f64,
+    pub h: f32,
+    pub s: f32,
+    pub l: f32,
 }
 
 impl From<Cubehelix> for Color {
     fn from(c: Cubehelix) -> Color {
-        const DEG2RAD: f64 = f64::PI / 180.0;
+        const DEG2RAD: f32 = f32::PI / 180.0;
         let h = (c.h + 120.0) * DEG2RAD;
         let l = c.l;
         let a = c.s * l * (1.0 - l);
@@ -25,7 +25,7 @@ impl From<Cubehelix> for Color {
     }
 }
 
-pub(crate) fn interpolate(start: Cubehelix, end: Cubehelix, t: f64) -> Cubehelix {
+pub(crate) fn interpolate(start: Cubehelix, end: Cubehelix, t: f32) -> Cubehelix {
     Cubehelix {
         h: start.h + t * (end.h - start.h),
         s: start.s + t * (end.s - start.s),

--- a/src/cyclical.rs
+++ b/src/cyclical.rs
@@ -3,7 +3,7 @@
 use crate::cubehelix::Cubehelix;
 use crate::gradient::EvalGradient;
 use crate::{Color, Gradient};
-use std::f64::consts as f64;
+use std::f32::consts as f32;
 
 /// &#8203;
 ///
@@ -21,7 +21,7 @@ impl EvalGradient for Rainbow {
         eval_rational(self, i, n)
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         let ts = (t - 0.5).abs();
         let h = 360.0 * t - 100.0;
         let s = 1.5 - 1.5 * ts;
@@ -46,13 +46,13 @@ impl EvalGradient for Sinebow {
         eval_rational(self, i, n)
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
-        let t = (0.5 - t) * f64::PI;
+    fn eval_continuous(&self, t: f32) -> Color {
+        let t = (0.5 - t) * f32::PI;
         let x = t.sin();
         let r = (255.0 * x * x) as u8;
-        let x = (t + f64::FRAC_PI_3).sin();
+        let x = (t + f32::FRAC_PI_3).sin();
         let g = (255.0 * x * x) as u8;
-        let x = (t + 2.0 * f64::FRAC_PI_3).sin();
+        let x = (t + 2.0 * f32::FRAC_PI_3).sin();
         let b = (255.0 * x * x) as u8;
         Color { r, g, b }
     }
@@ -63,5 +63,5 @@ impl EvalGradient for Sinebow {
 // gradient. For cyclical gradients the very first and very last color are the
 // same, so we want a different behavior.
 fn eval_rational(cyclic_gradient: &dyn EvalGradient, i: usize, n: usize) -> Color {
-    cyclic_gradient.eval_continuous(i as f64 / n as f64)
+    cyclic_gradient.eval_continuous(i as f32 / n as f32)
 }

--- a/src/diverging.rs
+++ b/src/diverging.rs
@@ -33,11 +33,11 @@ impl EvalGradient for Diverging {
             9 => self.nine[i],
             10 => self.ten[i],
             11 => self.eleven[i],
-            _ => self.eval_continuous(i as f64 / (n - 1) as f64),
+            _ => self.eval_continuous(i as f32 / (n - 1) as f32),
         }
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         interpolate::spline(&self.eleven, t)
     }
 }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -20,7 +20,7 @@ impl Gradient {
     /// Samples the gradient at position `t`. Requires `0.0 ≤ t ≤ 1.0`.
     pub fn eval_continuous(&self, t: f64) -> Color {
         let t = t.max(0.0).min(1.0);
-        self.eval.eval_continuous(t)
+        self.eval.eval_continuous(t as f32)
     }
 }
 
@@ -31,11 +31,11 @@ pub(crate) trait EvalGradient {
         if n <= 1 {
             self.eval_continuous(1.0)
         } else {
-            self.eval_continuous(i as f64 / (n - 1) as f64)
+            self.eval_continuous(i as f32 / (n - 1) as f32)
         }
     }
 
-    fn eval_continuous(&self, t: f64) -> Color;
+    fn eval_continuous(&self, t: f32) -> Color;
 }
 
 impl Debug for Gradient {

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -1,23 +1,23 @@
 use crate::Color;
 
-fn basis(colors: &[Color], component: fn(&Color) -> u8, t: f64) -> u8 {
+fn basis(colors: &[Color], component: fn(&Color) -> u8, t: f32) -> u8 {
     let n = colors.len() - 1;
-    let i = ((t * n as f64).floor() as usize).min(n - 1);
+    let i = ((t * n as f32).floor() as usize).min(n - 1);
 
-    let v1 = component(&colors[i]) as f64;
-    let v2 = component(&colors[i + 1]) as f64;
+    let v1 = component(&colors[i]) as f32;
+    let v2 = component(&colors[i + 1]) as f32;
     let v0 = if i > 0 {
-        component(&colors[i - 1]) as f64
+        component(&colors[i - 1]) as f32
     } else {
         2.0 * v1 - v2
     };
     let v3 = if i < n - 1 {
-        component(&colors[i + 2]) as f64
+        component(&colors[i + 2]) as f32
     } else {
         2.0 * v2 - v1
     };
 
-    let t1 = (t - i as f64 / n as f64) * n as f64;
+    let t1 = (t - i as f32 / n as f32) * n as f32;
     let t2 = t1 * t1;
     let t3 = t2 * t1;
 
@@ -29,7 +29,7 @@ fn basis(colors: &[Color], component: fn(&Color) -> u8, t: f64) -> u8 {
 }
 
 // 0.0 <= t <= 1.0
-pub fn spline(colors: &[Color], t: f64) -> Color {
+pub fn spline(colors: &[Color], t: f32) -> Color {
     Color {
         r: basis(colors, |c| c.r, t),
         g: basis(colors, |c| c.g, t),

--- a/src/sequential.rs
+++ b/src/sequential.rs
@@ -29,11 +29,11 @@ impl EvalGradient for Sequential {
             7 => self.seven[i],
             8 => self.eight[i],
             9 => self.nine[i],
-            _ => self.eval_continuous(i as f64 / (n - 1) as f64),
+            _ => self.eval_continuous(i as f32 / (n - 1) as f32),
         }
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         interpolate::spline(&self.nine, t)
     }
 }

--- a/src/sequential_multi.rs
+++ b/src/sequential_multi.rs
@@ -15,7 +15,7 @@ impl EvalGradient for Turbo {
         "Turbo"
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         let r = (34.61
             + t * (1172.33 - t * (10793.56 - t * (33300.12 - t * (38394.49 - t * 14825.05)))))
             .max(0.0)
@@ -41,7 +41,7 @@ impl EvalGradient for Ramp {
         self.name
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         interpolate::spline(&self.colors, t)
     }
 }
@@ -230,7 +230,7 @@ impl EvalGradient for Cividis {
         "Cividis"
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         let r = (-4.54 - t * (35.34 - t * (2381.73 - t * (6402.7 - t * (7024.72 - t * 2710.57)))))
             .max(0.0)
             .min(255.0) as u8;
@@ -255,7 +255,7 @@ impl EvalGradient for InterpolateCubehelix {
         self.name
     }
 
-    fn eval_continuous(&self, t: f64) -> Color {
+    fn eval_continuous(&self, t: f32) -> Color {
         cubehelix::interpolate(self.start, self.end, t).into()
     }
 }


### PR DESCRIPTION
`sed -i 's|\bf64\b|f32|g'`

None of the calculations here need the double precision. I guess I used f64 initially because this was all ported from JavaScript.

fyi @tarcieri