### PR TITLE
Add `no_std` compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
   - stable
 
 script:
+  - cargo test --no-default-features
   - cargo test
 
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,9 @@ image = "0.23"
 imageproc = "0.20"
 rusttype = "0.8"
 
+[features]
+default = ["std"]
+std = []
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug, LowerHex, UpperHex};
+use core::fmt::{self, Debug, LowerHex, UpperHex};
 
 /// &#8203;
 ///

--- a/src/cubehelix.rs
+++ b/src/cubehelix.rs
@@ -1,7 +1,11 @@
 #![allow(clippy::many_single_char_names)]
 
 use crate::Color;
-use std::f32::consts as f32;
+use core::f32::consts as f32;
+
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+use crate::math::F32Ext;
 
 #[derive(Copy, Clone)]
 pub(crate) struct Cubehelix {

--- a/src/cyclical.rs
+++ b/src/cyclical.rs
@@ -3,7 +3,11 @@
 use crate::cubehelix::Cubehelix;
 use crate::gradient::EvalGradient;
 use crate::{Color, Gradient};
-use std::f32::consts as f32;
+use core::f32::consts as f32;
+
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+use crate::math::F32Ext;
 
 /// &#8203;
 ///

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,6 +1,6 @@
 use crate::color::Color;
-use std::cmp;
-use std::fmt::{self, Debug};
+use core::cmp;
+use core::fmt::{self, Debug};
 
 #[derive(Copy, Clone)]
 pub struct Gradient {

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -1,5 +1,9 @@
 use crate::Color;
 
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+use crate::math::F32Ext;
+
 fn basis(colors: &[Color], component: fn(&Color) -> u8, t: f32) -> u8 {
     let n = colors.len() - 1;
     let i = ((t * n as f32).floor() as usize).min(n - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,6 @@
 //! Ten categorical colors authored by Tableau as part of [Tableau 10](https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782).
 
 #![no_std]
-
 #![doc(html_root_url = "https://docs.rs/colorous/1.0.1")]
 #![warn(clippy::pedantic)]
 #![allow(
@@ -290,9 +289,9 @@ mod cubehelix;
 mod cyclical;
 mod diverging;
 mod gradient;
+mod interpolate;
 #[cfg(not(feature = "std"))]
 mod math;
-mod interpolate;
 mod sequential;
 mod sequential_multi;
 mod sequential_single;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,6 +262,8 @@
 //!
 //! Ten categorical colors authored by Tableau as part of [Tableau 10](https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782).
 
+#![no_std]
+
 #![doc(html_root_url = "https://docs.rs/colorous/1.0.1")]
 #![warn(clippy::pedantic)]
 #![allow(
@@ -276,6 +278,9 @@
     clippy::unreadable_literal
 )]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[macro_use]
 mod macros;
 
@@ -285,6 +290,8 @@ mod cubehelix;
 mod cyclical;
 mod diverging;
 mod gradient;
+#[cfg(not(feature = "std"))]
+mod math;
 mod interpolate;
 mod sequential;
 mod sequential_multi;

--- a/src/math.rs
+++ b/src/math.rs
@@ -16,7 +16,6 @@ pub(crate) trait F32Ext: Sized {
     fn sin(self) -> f32;
 }
 
-
 impl F32Ext for f32 {
     fn abs(self) -> f32 {
         f32::from_bits(self.to_bits() & 0x7FFF_FFFF)

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,47 @@
+//! Floating point arithmetic approximations for `no_std` targets
+
+use core::f32::consts as f32;
+
+pub(crate) trait F32Ext: Sized {
+    /// Compute the absolute value of `n`
+    fn abs(self) -> f32;
+
+    /// Floor approximation
+    fn floor(self) -> f32;
+
+    /// Approximates `cos(x)` in radians with a maximum error of `0.002`
+    fn cos(self) -> f32;
+
+    /// Approximates `sin(x)` in radians with a maximum error of `0.002`
+    fn sin(self) -> f32;
+}
+
+
+impl F32Ext for f32 {
+    fn abs(self) -> f32 {
+        f32::from_bits(self.to_bits() & 0x7FFF_FFFF)
+    }
+
+    fn floor(self) -> f32 {
+        let mut trunc = (self as i32) as f32;
+
+        if self < trunc {
+            trunc -= 1.0;
+        }
+
+        trunc
+    }
+
+    fn cos(self) -> f32 {
+        let mut x = self;
+        x *= f32::FRAC_1_PI / 2.0;
+        x -= 0.25 + (x + 0.25).floor();
+        x *= 16.0 * (x.abs() - 0.5);
+        x += 0.225 * x * (x.abs() - 1.0);
+        x
+    }
+
+    fn sin(self) -> f32 {
+        (self - f32::PI / 2.0).cos()
+    }
+}

--- a/src/sequential_multi.rs
+++ b/src/sequential_multi.rs
@@ -16,19 +16,28 @@ impl EvalGradient for Turbo {
     }
 
     fn eval_continuous(&self, t: f32) -> Color {
-        let r = (34.61
-            + t * (1172.33 - t * (10793.56 - t * (33300.12 - t * (38394.49 - t * 14825.05)))))
-            .max(0.0)
-            .min(255.0) as u8;
-        let g = (23.31 + t * (557.33 + t * (1225.33 - t * (3574.96 - t * (1073.77 + t * 707.56)))))
-            .max(0.0)
-            .min(255.0) as u8;
-        let b = (27.2
-            + t * (3211.1 - t * (15327.97 - t * (27814.0 - t * (22569.18 - t * 6838.66)))))
-            .max(0.0)
-            .min(255.0) as u8;
-        Color { r, g, b }
+        let r =
+            34.61 + t * (1172.33 - t * (10793.56 - t * (33300.12 - t * (38394.49 - t * 14825.05))));
+        let g = 23.31 + t * (557.33 + t * (1225.33 - t * (3574.96 - t * (1073.77 + t * 707.56))));
+        let b = 27.2 + t * (3211.1 - t * (15327.97 - t * (27814.0 - t * (22569.18 - t * 6838.66))));
+        Color {
+            r: color_value(r),
+            g: color_value(g),
+            b: color_value(b),
+        }
     }
+}
+
+fn color_value(value: f32) -> u8 {
+    if value < 0.0 {
+        return 0;
+    }
+
+    if value > 255.0 {
+        return 255;
+    }
+
+    value as u8
 }
 
 struct Ramp {


### PR DESCRIPTION
Vendors floating point arithmetic/trig implementations used in the `micromath` crate as an `F32Ext` and uses them when `std` isn't enabled.

Closes #1