### PR TITLE
Make freestanding functions for math

### DIFF
--- a/src/cubehelix.rs
+++ b/src/cubehelix.rs
@@ -1,11 +1,8 @@
 #![allow(clippy::many_single_char_names)]
 
+use crate::math::{cos, sin};
 use crate::Color;
 use core::f32::consts as f32;
-
-#[cfg(not(feature = "std"))]
-#[allow(unused_imports)]
-use crate::math::F32Ext;
 
 #[derive(Copy, Clone)]
 pub(crate) struct Cubehelix {
@@ -20,8 +17,8 @@ impl From<Cubehelix> for Color {
         let h = (c.h + 120.0) * DEG2RAD;
         let l = c.l;
         let a = c.s * l * (1.0 - l);
-        let cosh = h.cos();
-        let sinh = h.sin();
+        let cosh = cos(h);
+        let sinh = sin(h);
         let r = (255.0 * (l - a * (0.14861 * cosh - 1.78277 * sinh)).min(1.0)) as u8;
         let g = (255.0 * (l - a * (0.29227 * cosh + 0.90649 * sinh)).min(1.0)) as u8;
         let b = (255.0 * (l + a * (1.97294 * cosh)).min(1.0)) as u8;

--- a/src/cyclical.rs
+++ b/src/cyclical.rs
@@ -2,12 +2,9 @@
 
 use crate::cubehelix::Cubehelix;
 use crate::gradient::EvalGradient;
+use crate::math::{abs, sin};
 use crate::{Color, Gradient};
 use core::f32::consts as f32;
-
-#[cfg(not(feature = "std"))]
-#[allow(unused_imports)]
-use crate::math::F32Ext;
 
 /// &#8203;
 ///
@@ -26,7 +23,7 @@ impl EvalGradient for Rainbow {
     }
 
     fn eval_continuous(&self, t: f32) -> Color {
-        let ts = (t - 0.5).abs();
+        let ts = abs(t - 0.5);
         let h = 360.0 * t - 100.0;
         let s = 1.5 - 1.5 * ts;
         let l = 0.8 - 0.9 * ts;
@@ -52,11 +49,11 @@ impl EvalGradient for Sinebow {
 
     fn eval_continuous(&self, t: f32) -> Color {
         let t = (0.5 - t) * f32::PI;
-        let x = t.sin();
+        let x = sin(t);
         let r = (255.0 * x * x) as u8;
-        let x = (t + f32::FRAC_PI_3).sin();
+        let x = sin(t + f32::FRAC_PI_3);
         let g = (255.0 * x * x) as u8;
-        let x = (t + 2.0 * f32::FRAC_PI_3).sin();
+        let x = sin(t + 2.0 * f32::FRAC_PI_3);
         let b = (255.0 * x * x) as u8;
         Color { r, g, b }
     }

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -1,12 +1,9 @@
+use crate::math::floor;
 use crate::Color;
-
-#[cfg(not(feature = "std"))]
-#[allow(unused_imports)]
-use crate::math::F32Ext;
 
 fn basis(colors: &[Color], component: fn(&Color) -> u8, t: f32) -> u8 {
     let n = colors.len() - 1;
-    let i = ((t * n as f32).floor() as usize).min(n - 1);
+    let i = (floor(t * n as f32) as usize).min(n - 1);
 
     let v1 = component(&colors[i]) as f32;
     let v2 = component(&colors[i + 1]) as f32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,9 +277,6 @@
     clippy::unreadable_literal
 )]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 #[macro_use]
 mod macros;
 
@@ -290,11 +287,12 @@ mod cyclical;
 mod diverging;
 mod gradient;
 mod interpolate;
-#[cfg(not(feature = "std"))]
-mod math;
 mod sequential;
 mod sequential_multi;
 mod sequential_single;
+
+#[cfg_attr(not(feature = "std"), path = "math_nostd.rs")]
+mod math;
 
 pub use crate::categorical::{
     ACCENT, CATEGORY10, DARK2, PAIRED, PASTEL1, PASTEL2, SET1, SET2, SET3, TABLEAU10,

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,46 +1,17 @@
-//! Floating point arithmetic approximations for `no_std` targets
+extern crate std;
 
-use core::f32::consts as f32;
-
-pub(crate) trait F32Ext: Sized {
-    /// Compute the absolute value of `n`
-    fn abs(self) -> f32;
-
-    /// Floor approximation
-    fn floor(self) -> f32;
-
-    /// Approximates `cos(x)` in radians with a maximum error of `0.002`
-    fn cos(self) -> f32;
-
-    /// Approximates `sin(x)` in radians with a maximum error of `0.002`
-    fn sin(self) -> f32;
+pub fn abs(x: f32) -> f32 {
+    x.abs()
 }
 
-impl F32Ext for f32 {
-    fn abs(self) -> f32 {
-        f32::from_bits(self.to_bits() & 0x7FFF_FFFF)
-    }
+pub fn floor(x: f32) -> f32 {
+    x.floor()
+}
 
-    fn floor(self) -> f32 {
-        let mut trunc = (self as i32) as f32;
+pub fn cos(x: f32) -> f32 {
+    x.cos()
+}
 
-        if self < trunc {
-            trunc -= 1.0;
-        }
-
-        trunc
-    }
-
-    fn cos(self) -> f32 {
-        let mut x = self;
-        x *= f32::FRAC_1_PI / 2.0;
-        x -= 0.25 + (x + 0.25).floor();
-        x *= 16.0 * (x.abs() - 0.5);
-        x += 0.225 * x * (x.abs() - 1.0);
-        x
-    }
-
-    fn sin(self) -> f32 {
-        (self - f32::PI / 2.0).cos()
-    }
+pub fn sin(x: f32) -> f32 {
+    x.sin()
 }

--- a/src/math_nostd.rs
+++ b/src/math_nostd.rs
@@ -1,0 +1,30 @@
+// Floating point arithmetic approximations for `no_std` targets. Vendored from:
+// https://github.com/NeoBirth/micromath/tree/e82158853632661e6ba411f145d222d9deb8babb
+
+use core::f32::consts as f32;
+
+pub fn abs(x: f32) -> f32 {
+    f32::from_bits(x.to_bits() & 0x7FFF_FFFF)
+}
+
+pub fn floor(x: f32) -> f32 {
+    let mut trunc = (x as i32) as f32;
+
+    if x < trunc {
+        trunc -= 1.0;
+    }
+
+    trunc
+}
+
+pub fn cos(mut x: f32) -> f32 {
+    x *= f32::FRAC_1_PI / 2.0;
+    x -= 0.25 + floor(x + 0.25);
+    x *= 16.0 * (abs(x) - 0.5);
+    x += 0.225 * x * (abs(x) - 1.0);
+    x
+}
+
+pub fn sin(x: f32) -> f32 {
+    cos(x - f32::PI / 2.0)
+}


### PR DESCRIPTION
This reduces the number of places that need `cfg(feature = "std")` to exactly 1, and eliminates the surprising warnings called out in https://github.com/dtolnay/colorous/pull/5#discussion_r419001126.