### PR TITLE
Restrict the type of EvalGradient to Send + Sync

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -4,7 +4,7 @@ use core::fmt::{self, Debug};
 
 #[derive(Copy, Clone)]
 pub struct Gradient {
-    pub(crate) eval: &'static dyn EvalGradient,
+    pub(crate) eval: &'static (dyn EvalGradient + Send + Sync),
 }
 
 impl Gradient {


### PR DESCRIPTION
I'm still learning Rust, so I hope I'm not missing something as to why these traits weren't listed before.