### PR TITLE
Guarantee Gradient is unwind safe if possible

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,10 +1,17 @@
 use crate::color::Color;
 use core::cmp;
 use core::fmt::{self, Debug};
+#[cfg(feature = "std")]
+use std::panic::{RefUnwindSafe, UnwindSafe};
+
+#[cfg(feature = "std")]
+type DynEvalGradient = dyn EvalGradient + Send + Sync + UnwindSafe + RefUnwindSafe;
+#[cfg(not(feature = "std"))]
+type DynEvalGradient = dyn EvalGradient + Send + Sync;
 
 #[derive(Copy, Clone)]
 pub struct Gradient {
-    pub(crate) eval: &'static (dyn EvalGradient + Send + Sync),
+    pub(crate) eval: &'static DynEvalGradient,
 }
 
 impl Gradient {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,9 @@
     clippy::unreadable_literal
 )]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
I may follow up with a PR to move the UnwindSafe marker traits from std to core...

Where this is relevant is code like:

```rust
fn main() {
    let gradient = colorous::VIRIDIS;
    let _ = std::panic::catch_unwind(|| { let _ = gradient; });
}
```

**Before:**

```console
error[E0277]: the type `(dyn colorous::gradient::EvalGradient + Send + Sync + 'static)` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> src/main.rs:3:13
    |
3   |     let _ = std::panic::catch_unwind(|| { let _ = gradient; });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn colorous::gradient::EvalGradient + Send + Sync + 'static)` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    | 
   ::: .rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:430:40
    |
430 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
    |                                        ---------- required by this bound in `catch_unwind`
    |
    = help: within `Gradient`, the trait `RefUnwindSafe` is not implemented for `(dyn colorous::gradient::EvalGradient + Send + Sync + 'static)`
    = note: required because it appears within the type `&'static (dyn colorous::gradient::EvalGradient + Send + Sync + 'static)`
    = note: required because it appears within the type `Gradient`
    = note: required because of the requirements on the impl of `UnwindSafe` for `&Gradient`
    = note: required because it appears within the type `[closure@src/main.rs:3:38: 3:62]`
```

**After:** works.