### PR TITLE
Make Gradient UnwindSafe on no_std on rust 1.56+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+// The rustc-cfg strings below are *not* public API.
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    if minor < 56 {
+        println!("cargo:rustc-cfg=unwind_safe_std_only");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,12 +1,14 @@
 use crate::color::Color;
 use core::cmp;
 use core::fmt::{self, Debug};
+#[cfg(not(any(feature = "std", unwind_safe_std_only)))]
+use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(feature = "std")]
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", not(unwind_safe_std_only)))]
 type DynEvalGradient = dyn EvalGradient + Send + Sync + UnwindSafe + RefUnwindSafe;
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), unwind_safe_std_only))]
 type DynEvalGradient = dyn EvalGradient + Send + Sync;
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
Courtesy of `UnwindSafe` and `RefUnwindSafe` getting moved to core by https://github.com/rust-lang/rust/pull/84662.