### PR TITLE
Add Tableau 20 and Petroffs categoricals

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,24 @@ Categorical color schemes are exposed simply as an array `[Color; N]`.
 
 Ten categorical colors authored by Tableau as part of [Tableau 10](https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782).
 
+<a href="#Tableau20" name="Tableau20">#</a> colorous::<b>TABLEAU20</b>
+
+<img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Tableau20.png" width="100%" height="40" alt="Tableau20">
+
+<a href="#Petroff6" name="Petroff6">#</a> colorous::<b>PETROFF6</b>
+
+<img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff6.png" width="100%" height="40" alt="Petroff6">
+
+<a href="#Petroff8" name="Petroff8">#</a> colorous::<b>PETROFF8</b>
+
+<img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff8.png" width="100%" height="40" alt="Petroff8">
+
+<a href="#Petroff10" name="Petroff10">#</a> colorous::<b>PETROFF10</b>
+
+<img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff10.png" width="100%" height="40" alt="Petroff10">
+
+Accessible color sequences authored by M. Petroff, [arxiv](https://arxiv.org/abs/2107.02270).
+
 <br>
 
 ## License

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -47,7 +47,7 @@ const GRADIENTS: [(Gradient, &str); 38] = [
     (SINEBOW, "SINEBOW"),
 ];
 
-const CATEGORICALS: [(&[Color], &str); 10] = [
+const CATEGORICALS: [(&[Color], &str); 14] = [
     (&CATEGORY10, "CATEGORY10"),
     (&ACCENT, "ACCENT"),
     (&DARK2, "DARK2"),
@@ -58,6 +58,10 @@ const CATEGORICALS: [(&[Color], &str); 10] = [
     (&SET2, "SET2"),
     (&SET3, "SET3"),
     (&TABLEAU10, "TABLEAU10"),
+    (&TABLEAU20, "TABLEAU20"),
+    (&PETROFF6, "PETROFF6"),
+    (&PETROFF8, "PETROFF8"),
+    (&PETROFF10, "PETROFF10"),
 ];
 
 fn main() {

--- a/src/categorical.rs
+++ b/src/categorical.rs
@@ -67,5 +67,33 @@ pub const SET3: [Color; 12] = colors! {
 ///
 /// <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Tableau10.png" width="100%" height="40" alt="Tableau10">
 pub const TABLEAU10: [Color; 10] = colors! {
-    0x4e79a7 0xf28e2c 0xe15759 0x76b7b2 0x59a14f 0xedc949 0xaf7aa1 0xff9da7 0x9c755f 0xbab0ab
+    0x4e79a7 0xf28e2b 0xe15759 0x76b7b2 0x59a14f 0xedc948 0xb07aa1 0xff9da7 0x9c755f 0xbab0ac
+};
+
+/// &#8203;
+///
+/// <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Tableau20.png" width="100%" height="40" alt="Tableau20">
+pub const TABLEAU20: [Color; 20] = colors! {
+    0x4e79a7 0xa0cbe8 0xf28e2b 0xffbe7d 0x59a14f 0x8cd17d 0xb6992d 0xf1ce63 0x499894 0x86bcb6 0xe15759 0xff9d9a 0x79706e 0xbab0ac 0xd37295 0xfabfd2 0xb07aa1 0xd4a6c8 0x9d7660 0xd7b5a6
+};
+
+/// &#8203;
+///
+/// <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff6.png" width="100%" height="40" alt="Petroff6">
+pub const PETROFF6: [Color; 6] = colors! {
+    0x5790fc 0xf89c20 0xe42536 0x964a8b 0x9c9ca1 0x7a21dd
+};
+
+/// &#8203;
+///
+/// <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff8.png" width="100%" height="40" alt="Petroff8">
+pub const PETROFF8: [Color; 8] = colors! {
+    0x1845fb 0xff5e02 0xc91f16 0xc849a9 0xadad7d 0x86c8dd 0x578dff 0x656364
+};
+
+/// &#8203;
+///
+/// <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff10.png" width="100%" height="40" alt="Petroff10">
+pub const PETROFF10: [Color; 10] = colors! {
+    0x3f90da 0xffa90e 0xbd1f01 0x94a4a2 0x832db6 0xa96b59 0xe76300 0xb9ac70 0x717581 0x92dadd
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,24 @@
 //! <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Tableau10.png" width="100%" height="40" alt="Tableau10">
 //!
 //! Ten categorical colors authored by Tableau as part of [Tableau 10](https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782).
+//!
+//! <a href="#Tableau20" name="Tableau20">#</a> colorous::<b>TABLEAU20</b>
+//!
+//! <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Tableau20.png" width="100%" height="40" alt="Tableau20">
+//!
+//! <a href="#Petroff6" name="Petroff6">#</a> colorous::<b>PETROFF6</b>
+//!
+//! <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff6.png" width="100%" height="40" alt="Petroff6">
+//!
+//! <a href="#Petroff8" name="Petroff8">#</a> colorous::<b>PETROFF8</b>
+//!
+//! <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff8.png" width="100%" height="40" alt="Petroff8">
+//!
+//! <a href="#Petroff10" name="Petroff10">#</a> colorous::<b>PETROFF10</b>
+//!
+//! <img src="https://raw.githubusercontent.com/dtolnay/colorous/readme/Petroff10.png" width="100%" height="40" alt="Petroff10">
+//!
+//! Accessible color sequences authored by M. Petroff, [arxiv](https://arxiv.org/abs/2107.02270).
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/colorous/1.0.16")]
@@ -307,7 +325,8 @@ mod sequential_single;
 mod math;
 
 pub use crate::categorical::{
-    ACCENT, CATEGORY10, DARK2, PAIRED, PASTEL1, PASTEL2, SET1, SET2, SET3, TABLEAU10,
+    ACCENT, CATEGORY10, DARK2, PAIRED, PASTEL1, PASTEL2, PETROFF10, PETROFF6, PETROFF8, SET1, SET2,
+    SET3, TABLEAU10, TABLEAU20,
 };
 pub use crate::color::Color;
 pub use crate::cyclical::{RAINBOW, SINEBOW};


### PR DESCRIPTION
Correct Tableau 10 colors based on linked image.

Add Tableau 20 based on https://jrnold.github.io/ggthemes/reference/tableau_color_pal.html.

Add Petroff color schemes (6, 8, 10 colors).

<img width="1800" height="398" alt="image" src="https://github.com/user-attachments/assets/8129b1ec-a93e-4b1f-b77c-0bf50536de92" />

**NOTE: Need uploading images in README**
